### PR TITLE
Add support to download images with redirects

### DIFF
--- a/src/ImageUploader.php
+++ b/src/ImageUploader.php
@@ -146,6 +146,7 @@ class ImageUploader
         curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
         curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, false);
         curl_setopt($ch, CURLOPT_SSL_VERIFYHOST, 2);
+        curl_setopt($ch, CURLOPT_FOLLOWLOCATION, true);
         $image_data = curl_exec($ch);
 
         if ($image_data === false) {


### PR DESCRIPTION
It will enable the plugin to download images which starts with `http://` but target server redirects to `https://`. Another case this change will help with is redirects from non-www to www or vice versa. Fixes https://github.com/airani/wp-auto-upload/issues/26